### PR TITLE
Add on-wiki config to define default fonts

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -61,5 +61,6 @@
 	"error-page-header": "An error occurred",
 	"error-page-details": "Error details: $1",
 	"error-page-issue": "If this error persists, please $1.",
-	"error-page-issue-link": "report an issue on Phabricator"
+	"error-page-issue-link": "report an issue on Phabricator",
+	"onwikiconfig-failure": "Unable to retrieve the on-wiki configuration from: $1"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -63,5 +63,6 @@
 	"error-page-header": "Header text for the generic error page.",
 	"error-page-details": "Introduction text to the generic error page.\n\n$1 - Error description.",
 	"error-page-issue": "Call to action text.\n\n$1 - HTML link, with text from error-page-issue-link below.",
-	"error-page-issue-link": "Link text to use in the link in error-page-issue above."
+	"error-page-issue-link": "Link text to use in the link in error-page-issue above.",
+	"onwikiconfig-failure": "Error message displayed if the on-wiki configuration fetching failed.\n\n* $1 - the URL of the config JSON page on Wikisource."
 }

--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -106,7 +106,7 @@ class ExportController extends AbstractController {
 			}
 		}
 
-		$font = $this->getFont( $request, $api->getLang(), $fontProvider );
+		$font = $this->getFont( $request, $fontProvider );
 		$credits = (bool)$request->get( 'credits', true );
 		$images = (bool)$request->get( 'images', true );
 		return $this->render( 'export.html.twig', [
@@ -135,7 +135,7 @@ class ExportController extends AbstractController {
 		// Get params.
 		$page = $request->get( 'page' );
 		$format = $this->getFormat( $request );
-		$font = $this->getFont( $request, $api->getLang(), $fontProvider );
+		$font = $this->getFont( $request, $fontProvider );
 		// The `credits` checkbox submits as 'false' to disable, so needs extra filtering.
 		$credits = filter_var( $request->get( 'credits', true ), FILTER_VALIDATE_BOOL );
 		// The `images` checkbox submits as 'false' to disable, so needs extra filtering.
@@ -173,14 +173,14 @@ class ExportController extends AbstractController {
 	 * Get a font name from the given request, falling back to the default (which depends on the language).
 	 *
 	 * @param Request $request The current request.
-	 * @param string $lang A language code.
+	 * @param FontProvider $fontProvider
+	 * @param bool|null $getDefault Whether to try to retrieve the Wikisource's default font.
 	 * @return string|null
 	 */
-	private function getFont( Request $request, $lang, FontProvider $fontProvider ): ?string {
-		// Default font for non-latin languages.
+	private function getFont( Request $request, FontProvider $fontProvider, ?bool $getDefault = true ): ?string {
 		$font = $fontProvider->resolveName( $request->get( 'fonts' ) );
-		if ( !$font && !in_array( $lang, [ 'fr', 'en', 'de', 'it', 'es', 'pt', 'vec', 'pl', 'nl', 'fa', 'he', 'ar', 'zh', 'jp', 'kr' ] ) ) {
-			$font = 'FreeSerif';
+		if ( !$font && $getDefault ) {
+			$font = $fontProvider->getDefault( $this->getLang( $request ) );
 		}
 		if ( !$fontProvider->getOne( $font ) ) {
 			$font = '';
@@ -232,5 +232,4 @@ class ExportController extends AbstractController {
 		// but for error pages it's useful.
 		return ucfirst( str_replace( '_', ' ', $request->get( 'title', $request->get( 'page' ) ) ) );
 	}
-
 }

--- a/src/FontProvider.php
+++ b/src/FontProvider.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use App\Util\OnWikiConfig;
 use DateInterval;
 use Symfony\Component\Process\Process;
 use Symfony\Contracts\Cache\CacheInterface;
@@ -27,9 +28,21 @@ class FontProvider {
 	/** @var string[] Runtime cache of variants of font names. */
 	private $names;
 
-	public function __construct( CacheInterface $cache ) {
+	/** @var OnWikiConfig */
+	private $onWikiConfig;
+
+	public function __construct( CacheInterface $cache, OnWikiConfig $config ) {
 		$this->cache = $cache;
 		$this->names = [];
+		$this->onWikiConfig = $config;
+	}
+
+	/**
+	 * @param string $lang
+	 * @return string
+	 */
+	public function getDefault( string $lang ): string {
+		return $this->onWikiConfig->getDefaultFont( $lang );
 	}
 
 	/**

--- a/src/Util/OnWikiConfig.php
+++ b/src/Util/OnWikiConfig.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Util;
+
+use DateInterval;
+use DateTime;
+use GuzzleHttp\Exception\ConnectException;
+use Krinkle\Intuition\Intuition;
+use Psr\Cache\CacheItemInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+
+class OnWikiConfig {
+
+	/** @var Api */
+	private $api;
+
+	/** @var CacheInterface */
+	private $cache;
+
+	/** @var Intuition */
+	private $intuition;
+
+	/** @var mixed[] The config data, retrieved from the wiki. */
+	private $data;
+
+	public function __construct( Api $api, CacheInterface $cache, Intuition $intuition ) {
+		$this->api = $api;
+		$this->cache = $cache;
+		$this->intuition = $intuition;
+	}
+
+	/**
+	 * Get the on-wiki configuration from the `MediaWiki:WS_Export.json` page. Cached for 1 month.
+	 * @return mixed[] With keys: defaultFont
+	 */
+	private function getData( string $lang ): array {
+		if ( isset( $this->data[ $lang ] ) ) {
+			return $this->data[ $lang ];
+		}
+		$this->api->setLang( $lang );
+		$this->data[ $lang ] = $this->cache->get( 'OnWikiConfig_' . $lang, function ( CacheItemInterface $cacheItem ) {
+			$cacheItem->expiresAfter( new DateInterval( 'P1M' ) );
+			$configPageName = 'MediaWiki:WS_Export.json';
+			try {
+				$dataUrl = 'https://' . $this->api->getDomainName() . '/w/index.php?title=' . $configPageName . '&action=raw&ctype=application/json';
+				$json = $this->api->get( $dataUrl );
+			} catch ( ConnectException $exception ) {
+				// If an invalid wiki language, or connection fails for any reason.
+				$json = '{}';
+			}
+			$data = json_decode( $json, true );
+			if ( $data === null ) {
+				$data = [];
+			}
+			if ( !$data ) {
+				// Don't cache the empty result.
+				$cacheItem->expiresAt( new DateTime() );
+			}
+			return $data;
+		} );
+		return $this->data[ $lang ];
+	}
+
+	/**
+	 * Get the name of the default font to embed in exports.
+	 *
+	 * @param string $lang
+	 * @return string
+	 */
+	public function getDefaultFont( string $lang ): string {
+		$config = $this->getData( $lang );
+		return $config['defaultFont'] ?? '';
+	}
+}

--- a/templates/export.html.twig
+++ b/templates/export.html.twig
@@ -76,7 +76,7 @@
 	<div class="form-group">
 		<label for="fonts" class="control-label">{{ msg( 'font-field-label' ) }}</label>
 		<select id="fonts" name="fonts" class="form-control">
-			<option value="">{{ msg( 'no-font-option' ) }}</option>
+			<option value=""{% if not font %} selected="selected"{% endif %}>{{ msg( 'no-font-option' ) }}</option>
 			{% for key,label in fonts %}
 				<option value="{{ key|e('html_attr') }}" {% if key == font %}selected="selected"{% endif %}>
 					{{ key }}

--- a/tests/Book/GeneratorSelectorTest.php
+++ b/tests/Book/GeneratorSelectorTest.php
@@ -7,6 +7,7 @@ use App\Generator\ConvertGenerator;
 use App\Generator\EpubGenerator;
 use App\GeneratorSelector;
 use App\Util\Api;
+use App\Util\OnWikiConfig;
 use Exception;
 use Krinkle\Intuition\Intuition;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -31,8 +32,8 @@ class GeneratorSelectorTest extends KernelTestCase {
 
 	public function setUp(): void {
 		parent::setUp();
-		$this->fontProvider = new FontProvider( new ArrayAdapter() );
 		self::bootKernel();
+		$this->fontProvider = new FontProvider( new ArrayAdapter(), self::$container->get( OnWikiConfig::class ) );
 		$this->api = self::$container->get( Api::class );
 		$this->intuition = self::$container->get( Intuition::class );
 		$convertGenerator = new ConvertGenerator( $this->fontProvider, $this->api, $this->intuition, 10 );

--- a/tests/BookCreator/BookCreatorIntegrationTest.php
+++ b/tests/BookCreator/BookCreatorIntegrationTest.php
@@ -9,6 +9,7 @@ use App\Generator\ConvertGenerator;
 use App\GeneratorSelector;
 use App\Repository\CreditRepository;
 use App\Util\Api;
+use App\Util\OnWikiConfig;
 use Krinkle\Intuition\Intuition;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -39,7 +40,7 @@ class BookCreatorIntegrationTest extends KernelTestCase {
 
 	public function setUp(): void {
 		self::bootKernel();
-		$this->fontProvider = new FontProvider( new ArrayAdapter() );
+		$this->fontProvider = new FontProvider( new ArrayAdapter(), self::$container->get( OnWikiConfig::class ) );
 		$this->api = self::$container->get( Api::class );
 		$this->intuition = self::$container->get( Intuition::class );
 		$convertGenerator = new ConvertGenerator( $this->fontProvider, $this->api, $this->intuition, 10 );

--- a/tests/FontProviderTest.php
+++ b/tests/FontProviderTest.php
@@ -3,8 +3,16 @@
 namespace App\Tests;
 
 use App\FontProvider;
+use App\Util\Api;
+use App\Util\OnWikiConfig;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use Krinkle\Intuition\Intuition;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\NullAdapter;
 
 class FontProviderTest extends TestCase {
 
@@ -13,7 +21,9 @@ class FontProviderTest extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->fontProvider = new FontProvider( new ArrayAdapter() );
+		$client = new Client( [ 'handler' => HandlerStack::create( new MockHandler( [] ) ) ] );
+		$api = new Api( new NullLogger(), new NullAdapter(), new NullAdapter(), $client, 0 );
+		$this->fontProvider = new FontProvider( new ArrayAdapter(), new OnWikiConfig( $api, new ArrayAdapter(), new Intuition() ) );
 	}
 
 	/**

--- a/tests/Http/BookTest.php
+++ b/tests/Http/BookTest.php
@@ -100,4 +100,20 @@ class BookTest extends WebTestCase {
 		$this->assertStringContainsString( '<input name="page" id="page" type="text" size="30" required="required" class="form-control"
 			value="A &quot;title&quot;" />', $client->getResponse()->getContent() );
 	}
+
+	public function testFonts() {
+		$client = static::createClient();
+		// No font.
+		$client->request( 'GET', '/', [ 'fonts' => 'Not a font name' ] );
+		$this->assertStringContainsString( '<option value="" selected="selected">None (use device default)</option>', $client->getResponse()->getContent() );
+		// Default when there's no on-wiki config.
+		$client->request( 'GET', '/', [ 'lang' => 'en' ] );
+		$this->assertStringContainsString( '<option value="" selected="selected">None (use device default)</option>', $client->getResponse()->getContent() );
+		// Default font from on-wiki config.
+		$client->request( 'GET', '/', [ 'lang' => 'beta' ] );
+		$this->assertStringContainsString( '<option value="DejaVu&#x20;Sans&#x20;Mono" selected="selected">', $client->getResponse()->getContent() );
+		// Default is overridden in request.
+		$client->request( 'GET', '/', [ 'lang' => 'beta', 'fonts' => 'DejaVu Serif' ] );
+		$this->assertStringContainsString( '<option value="DejaVu&#x20;Serif" selected="selected">', $client->getResponse()->getContent() );
+	}
 }

--- a/tests/Util/OnWikiConfigTest.php
+++ b/tests/Util/OnWikiConfigTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Tests\Util;
+
+use App\Util\Api;
+use App\Util\OnWikiConfig;
+use Krinkle\Intuition\Intuition;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\NullAdapter;
+
+class OnWikiConfigTest extends TestCase {
+
+	/**
+	 * @covers \App\Util\OnWikiConfig::getDefaultFont()
+	 */
+	public function testGetDefaultFont() {
+		/** @var Api $api */
+		$api = $this->createMock( Api::class );
+
+		// Set up getDomainName() to return whatever was given to setLang(), for ease of testing.
+		$lang = null;
+		$api->expects( $this->exactly( 3 ) )->method( 'setLang' )->willReturnCallback(
+			function ( $arg ) use ( &$lang ) {
+				$lang = $arg;
+			}
+		);
+		$api->expects( $this->exactly( 3 ) )
+			->method( 'getDomainName' )
+			->willReturnCallback( function () use ( &$lang ) {
+				return $lang;
+			} );
+
+		// Set up the mock JSON string responses.
+		$api->expects( $this->exactly( 3 ) )
+			->method( 'get' )
+			->will( $this->returnValueMap( [
+				[ 'https://xxx/w/index.php?title=MediaWiki:WS_Export.json&action=raw&ctype=application/json', '', ],
+				[ 'https://en/w/index.php?title=MediaWiki:WS_Export.json&action=raw&ctype=application/json', '', ],
+				[ 'https://beta/w/index.php?title=MediaWiki:WS_Export.json&action=raw&ctype=application/json', '{"defaultFont": "Beta Font"}', ],
+			] ) );
+
+		$onWikiConfig = new OnWikiConfig( $api, new NullAdapter(), new Intuition() );
+
+		// Invalid language.
+		$this->assertSame( '', $onWikiConfig->getDefaultFont( 'xxx' ) );
+		// English has no default font set.
+		$this->assertSame( '', $onWikiConfig->getDefaultFont( 'en' ) );
+		// Beta has a default.
+		$this->assertSame( 'Beta Font', $onWikiConfig->getDefaultFont( 'beta' ) );
+	}
+
+}


### PR DESCRIPTION
Set up an on-wiki config page MediaWiki:WS_Export.json, which
can be used to store any per-Wikisource configuration. So far
this is just `defaultFont` but it can be extended as needed.

Defaults for these configs live in the tool's code, not in
Multilingual Wikisource (like the About page) because that wiki
will need its own config.

The existing default of FreeSerif will need to be migrated to
the on-wiki config once this change has been merged.

Bug: https://phabricator.wikimedia.org/T274561