### PR TITLE
Remove exec-timeout global variable

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -18,6 +18,5 @@ if ( !is_array( $wsexportConfig ) ) {
 	$container = $kernelTmp->getContainer();
 	$wsexportConfig = [
 		'tempPath' => $container->getParameter( 'app.tempPath' ) ?? dirname( __DIR__ ) . '/var/',
-		'exec-timeout' => $container->getParameter( 'app.execTimeout' ),
 	];
 }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -5,7 +5,6 @@
 # https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
     app.tempPath: '%env(default::APP_TEMP_PATH)%'
-    app.execTimeout: '%env(default::int:APP_TIMEOUT)%'
 
 services:
     # default configuration for services in *this* file
@@ -57,6 +56,10 @@ services:
     App\Util\Api:
         arguments:
             $cacheTtl: '%env(int:APP_CACHE_TTL)%'
+
+    App\Generator\ConvertGenerator:
+        arguments:
+            $timeout: '%env(default::int:APP_TIMEOUT)%'
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones

--- a/src/Generator/ConvertGenerator.php
+++ b/src/Generator/ConvertGenerator.php
@@ -86,16 +86,23 @@ class ConvertGenerator implements FormatGenerator {
 	/** @var Api */
 	private $api;
 
+	/** @var int Command timeout in seconds. */
+	private $timeout;
+
+	public function __construct( FontProvider $fontProvider, Api $api, int $timeout ) {
+		$this->fontProvider = $fontProvider;
+		$this->api = $api;
+		$this->timeout = $timeout;
+	}
+
 	/**
 	 * @param string $format
 	 */
-	public function __construct( $format, FontProvider $fontProvider, Api $api ) {
+	public function setFormat( string $format ): void {
 		if ( !array_key_exists( $format, self::$CONFIG ) ) {
 			throw new InvalidArgumentException( 'Invalid format: ' . $format );
 		}
 		$this->format = $format;
-		$this->fontProvider = $fontProvider;
-		$this->api = $api;
 	}
 
 	/**
@@ -142,14 +149,12 @@ class ConvertGenerator implements FormatGenerator {
 	}
 
 	private function convert( $epubFileName, $outputFileName ) {
-		global $wsexportConfig;
-
 		$command = array_merge(
 			[ $this->getEbookConvertCommand(), $epubFileName, $outputFileName ],
 			explode( ' ', self::$CONFIG[$this->format]['parameters'] )
 		);
 		$process = new Process( $command );
-		$process->setTimeout( $wsexportConfig['exec-timeout'] ?? 120 );
+		$process->setTimeout( $this->timeout ?? 120 );
 		$process->mustRun();
 	}
 

--- a/src/GeneratorSelector.php
+++ b/src/GeneratorSelector.php
@@ -40,9 +40,13 @@ class GeneratorSelector {
 	/** @var Api */
 	private $api;
 
-	public function __construct( FontProvider $fontProvider, Api $api ) {
+	/** @var ConvertGenerator */
+	private $convertGenerator;
+
+	public function __construct( FontProvider $fontProvider, Api $api, ConvertGenerator $convertGenerator ) {
 		$this->fontProvider = $fontProvider;
 		$this->api = $api;
+		$this->convertGenerator = $convertGenerator;
 	}
 
 	/**
@@ -67,7 +71,8 @@ class GeneratorSelector {
 		if ( $format === 'epub-3' ) {
 			return new EpubGenerator( $this->fontProvider, $this->api );
 		} elseif ( in_array( $format, ConvertGenerator::getSupportedTypes() ) ) {
-			return new ConvertGenerator( $format, $this->fontProvider, $this->api );
+			$this->convertGenerator->setFormat( $format );
+			return $this->convertGenerator;
 		} elseif ( $format === 'atom' ) {
 			return new AtomGenerator();
 		} else {

--- a/tests/Book/GeneratorSelectorTest.php
+++ b/tests/Book/GeneratorSelectorTest.php
@@ -30,7 +30,8 @@ class GeneratorSelectorTest extends KernelTestCase {
 		$this->fontProvider = new FontProvider( new ArrayAdapter() );
 		self::bootKernel();
 		$this->api = self::$container->get( Api::class );
-		$this->generatorSelector = new GeneratorSelector( $this->fontProvider, $this->api );
+		$convertGenerator = new ConvertGenerator( $this->fontProvider, $this->api, 10 );
+		$this->generatorSelector = new GeneratorSelector( $this->fontProvider, $this->api, $convertGenerator );
 	}
 
 	public function testGetUnknownGeneratorRaisesException() {

--- a/tests/BookCreator/BookCreatorIntegrationTest.php
+++ b/tests/BookCreator/BookCreatorIntegrationTest.php
@@ -5,6 +5,7 @@ namespace App\Tests\BookCreator;
 use App\BookCreator;
 use App\EpubCheck\EpubCheck;
 use App\FontProvider;
+use App\Generator\ConvertGenerator;
 use App\GeneratorSelector;
 use App\Util\Api;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -32,7 +33,8 @@ class BookCreatorIntegrationTest extends KernelTestCase {
 		self::bootKernel();
 		$this->fontProvider = new FontProvider( new ArrayAdapter() );
 		$this->api = self::$container->get( Api::class );
-		$this->generatorSelector = new GeneratorSelector( $this->fontProvider, $this->api );
+		$convertGenerator = new ConvertGenerator( $this->fontProvider, $this->api, 10 );
+		$this->generatorSelector = new GeneratorSelector( $this->fontProvider, $this->api, $convertGenerator );
 		$this->epubCheck = self::$container->get( EpubCheck::class );
 	}
 


### PR DESCRIPTION
Inject the timeout value instead of retrieving it from a global
variable. This isn't the cleanest way to implement this, because
it perpetuates the statefulness of ConvertGenerator, but it
isn't any worse than the existing code!

Bug: https://phabricator.wikimedia.org/T265854