### PR TITLE
CreditRepository: Close connection as soon as query finishes

### DIFF
--- a/src/Repository/CreditRepository.php
+++ b/src/Repository/CreditRepository.php
@@ -88,6 +88,8 @@ class CreditRepository {
 				GROUP BY actor_name
 				ORDER BY count DESC"
 			);
+		$connection->close();
+
 		return $results ? $results : [];
 	}
 
@@ -141,6 +143,8 @@ class CreditRepository {
 					)
 				  ) a"
 			);
+		$connection->close();
+
 		return $results ? $results : [];
 	}
 }


### PR DESCRIPTION
Otherwise the connection can stay open for the entire time the book is
being exported, making us vulnerable of hitting our concurrent
connection limit.