### PR TITLE
Further improve handling of common errors

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -62,5 +62,7 @@
 	"error-page-details": "Error details: $1",
 	"error-page-issue": "If this error persists, please $1.",
 	"error-page-issue-link": "report an issue on Phabricator",
-	"onwikiconfig-failure": "Unable to retrieve the on-wiki configuration from: $1"
+	"onwikiconfig-failure": "Unable to retrieve the on-wiki configuration from: $1",
+	"exception-fetching-credits": "Error fetching credits information. Please try exporting again. If this error persists, check the box in 'Options' to remove credits.",
+	"exception-book-conversion": "Error converting the format of the book."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -64,5 +64,7 @@
 	"error-page-details": "Introduction text to the generic error page.\n\n$1 - Error description.",
 	"error-page-issue": "Call to action text.\n\n$1 - HTML link, with text from error-page-issue-link below.",
 	"error-page-issue-link": "Link text to use in the link in error-page-issue above.",
-	"onwikiconfig-failure": "Error message displayed if the on-wiki configuration fetching failed.\n\n* $1 - the URL of the config JSON page on Wikisource."
+	"onwikiconfig-failure": "Error message displayed if the on-wiki configuration fetching failed.\n\n* $1 - the URL of the config JSON page on Wikisource.",
+	"exception-fetching-credits": "Error message displayed when credits information could not be retrieved.",
+	"exception-book-conversion": "Error message displayed when a book could not be converted to another format."
 }

--- a/src/Exception/WsExportException.php
+++ b/src/Exception/WsExportException.php
@@ -15,11 +15,22 @@ class WsExportException extends Exception {
 	/** @var int */
 	private $responseCode;
 
-	public function __construct( string $i18nMessage, array $i18nParams, int $reponseCode ) {
+	/** @var bool */
+	private $friendly;
+
+	/**
+	 * WsExportException constructor.
+	 * @param string $i18nMessage
+	 * @param array $i18nParams
+	 * @param int $responseCode
+	 * @param bool $friendly `true` will mean a 'Learn more' link will be shown with troubleshooting tips.
+	 */
+	public function __construct( string $i18nMessage, array $i18nParams, int $responseCode, bool $friendly = true ) {
 		parent::__construct();
 		$this->i18nMessage = $i18nMessage;
 		$this->i18nParams = $i18nParams;
-		$this->responseCode = $reponseCode;
+		$this->responseCode = $responseCode;
+		$this->friendly = $friendly;
 	}
 
 	public function getI18nMessage(): string {
@@ -32,5 +43,13 @@ class WsExportException extends Exception {
 
 	public function getResponseCode(): int {
 		return $this->responseCode;
+	}
+
+	/**
+	 * Is this a 'friendly' error message ('Learn more' tips should be shown)?
+	 * @return bool
+	 */
+	public function isFriendly(): bool {
+		return $this->friendly;
 	}
 }

--- a/src/Util/Api.php
+++ b/src/Util/Api.php
@@ -274,7 +274,7 @@ class Api {
 						return Util::getXhtmlFromContent( $this->getLang(), $result, $title );
 					},
 					function ( $reason ) use ( $title ) {
-						throw new WsExportException( 'rest-page-not-found', [ $title ], 404 );
+						throw new WsExportException( 'rest-page-not-found', [ $title ], 404, false );
 					}
 				);
 	}

--- a/templates/export.html.twig
+++ b/templates/export.html.twig
@@ -22,10 +22,16 @@
 			<p class="message-inner">
 				<strong>{{ msg( 'export-failed' ) }}</strong>
 				<span>{{ msg( exception.i18nMessage, exception.i18nParams ) }}</span>
-				<button id="learn-more-link" type="button" role="button" data-toggle="collapse" class="btn btn-link alert-link"
-						data-target="#learn-more-body" aria-expanded="false" aria-controls="learn-more-body">
-					{{ msg( 'learn-more' ) }}
-				</button>
+				{% if exception.friendly %}
+					{# Friendly errors show a 'Learn more' link with troubleshooting tips. #}
+					<button id="learn-more-link" type="button" role="button" data-toggle="collapse" class="btn btn-link alert-link"
+							data-target="#learn-more-body" aria-expanded="false" aria-controls="learn-more-body">
+						{{ msg( 'learn-more' ) }}
+					</button>
+				{% else %}
+					{# To maintain vertical spacing with X icon on the left. #}
+					<button class="btn invisible">&nbsp;</button>
+				{% endif %}
 			</p>
 			<div id="learn-more-body" class="collapse">
 				<hr />


### PR DESCRIPTION
This covers errors thrown when doing format conversions, MySQL timeout
and max_user_connections errors.

This also hides the 'Learn more' link for 404 errors since re-trying
won't help in that case.

Bug: https://phabricator.wikimedia.org/T278189