### PR TITLE
Sanitize cache keys

### DIFF
--- a/src/Util/Api.php
+++ b/src/Util/Api.php
@@ -103,7 +103,8 @@ class Api {
 		if ( isset( $this->namespaces[ $this->getLang() ] ) ) {
 			return $this->namespaces[ $this->getLang() ];
 		}
-		$this->namespaces[ $this->getLang() ] = $this->cache->get( 'namespaces_' . $this->getLang(), function ( CacheItemInterface $cacheItem ) {
+		$cacheKey = Util::sanitizeCacheKey( 'namespaces_' . $this->getLang() );
+		$this->namespaces[ $this->getLang() ] = $this->cache->get( $cacheKey, function ( CacheItemInterface $cacheItem ) {
 			$this->logger->notice( 'Fetching namespace names for ' . $this->getLang() );
 			$cacheItem->expiresAfter( new DateInterval( 'P1M' ) );
 			$response = $this->queryAsync( [ 'meta' => 'siteinfo', 'siprop' => 'namespaces|namespacealiases' ] )
@@ -133,7 +134,8 @@ class Api {
 	 * @return string The HTML.
 	 */
 	public function getAboutPage(): string {
-		$content = $this->cache->get( 'about_' . $this->getLang(), function ( CacheItemInterface $cacheItem ) {
+		$cacheKey = Util::sanitizeCacheKey( 'about_' . $this->getLang() );
+		$content = $this->cache->get( $cacheKey, function ( CacheItemInterface $cacheItem ) {
 			// Cache for 1 month.
 			$cacheItem->expiresAfter( new DateInterval( 'P1M' ) );
 			// Get the HTML from either this Wikisource or multilingual Wikisource.

--- a/src/Util/OnWikiConfig.php
+++ b/src/Util/OnWikiConfig.php
@@ -38,7 +38,8 @@ class OnWikiConfig {
 			return $this->data[ $lang ];
 		}
 		$this->api->setLang( $lang );
-		$this->data[ $lang ] = $this->cache->get( 'OnWikiConfig_' . $lang, function ( CacheItemInterface $cacheItem ) {
+		$cacheKey = Util::sanitizeCacheKey( 'OnWikiConfig_' . $lang );
+		$this->data[ $lang ] = $this->cache->get( $cacheKey, function ( CacheItemInterface $cacheItem ) {
 			$cacheItem->expiresAfter( new DateInterval( 'P1M' ) );
 			$configPageName = 'MediaWiki:WS_Export.json';
 			try {

--- a/src/Util/Util.php
+++ b/src/Util/Util.php
@@ -230,4 +230,13 @@ class Util {
 		$document->encoding = 'UTF-8';
 		return $document;
 	}
+
+	/**
+	 * Remove reserved characters from a cache key.
+	 * @param string $key
+	 * @return string
+	 */
+	public static function sanitizeCacheKey( string $key ): string {
+		return preg_replace( '/[{}()\/\@\:"]/', '-', $key );
+	}
 }


### PR DESCRIPTION
This prevents InvalidArgumentExceptions that happen from erroneous user
input for the lang= parameter.