### PR TITLE
Improve subpage-finding to not use URLs

### DIFF
--- a/src/Page.php
+++ b/src/Page.php
@@ -20,4 +20,17 @@ class Page {
 
 	/** @var Page[] List of the subpages. */
 	public $chapters = [];
+
+	/**
+	 * Convenience method to create a new page with a name and title.
+	 * @param string $name
+	 * @param string $title
+	 * @return Page
+	 */
+	public static function factory( string $name, string $title ) {
+		$page = new self();
+		$page->title = $title;
+		$page->name = $name;
+		return $page;
+	}
 }


### PR DESCRIPTION
This changes the chapter subpage finding logic (when there's no
ws-summary in use) to use the links' title attribute rather than
their href attribute. It also moves the prefix-searching out of
XPath and into the link loop.

Bug: https://phabricator.wikimedia.org/T275870