### PR TITLE
Remove `mw:Extension` link elements

### DIFF
--- a/src/PageParser.php
+++ b/src/PageParser.php
@@ -269,6 +269,7 @@ class PageParser {
 		$this->removeNodesWithXpath( '//a[@class="mw-headline-anchor"]' );
 		$this->removeNodesWithXpath( '//div[@class="mediaContainer"]' );
 		$this->removeNodesWithXpath( '//link[@rel="mw:PageProp/Category"]' );
+		$this->removeNodesWithXpath( '//link[contains(@typeof, "mw:Extension")]' );
 		$this->deprecatedNodes( 'big', 'span', 'font-size:large;' );
 		$this->deprecatedNodes( 'center', 'div', 'text-align:center;' );
 		$this->deprecatedNodes( 'strike', 'span', 'text-decoration:line-through;' );


### PR DESCRIPTION
These are not valid in EPUBs.

Bug: https://phabricator.wikimedia.org/T272819