### PR TITLE
Remove configurability of ebook-convert CLI command

### DIFF
--- a/src/Generator/ConvertGenerator.php
+++ b/src/Generator/ConvertGenerator.php
@@ -159,7 +159,7 @@ class ConvertGenerator implements FormatGenerator {
 	private function convert( $epubFileName, $outputFileName ) {
 		try {
 			$command = array_merge(
-				[ $this->getEbookConvertCommand(), $epubFileName, $outputFileName ],
+				[ 'ebook-convert', $epubFileName, $outputFileName ],
 				explode( ' ', self::$CONFIG[$this->format]['parameters'] )
 			);
 			$process = new Process( $command );
@@ -168,10 +168,5 @@ class ConvertGenerator implements FormatGenerator {
 		} catch ( ProcessTimedOutException $e ) {
 			throw new WsExportException( 'book-conversion', [], Response::HTTP_INTERNAL_SERVER_ERROR );
 		}
-	}
-
-	private function getEbookConvertCommand() {
-		global $wsexportConfig;
-		return array_key_exists( 'ebook-convert', $wsexportConfig ) ? $wsexportConfig['ebook-convert'] : 'ebook-convert';
 	}
 }


### PR DESCRIPTION
It's no longer being configured, and getting rid of it removes
one of the remaining global config variables.

Bug: https://phabricator.wikimedia.org/T265854