### PR TITLE
Use Symfony caching for CSS, rather than FileCache

### DIFF
--- a/src/Generator/ConvertGenerator.php
+++ b/src/Generator/ConvertGenerator.php
@@ -12,6 +12,7 @@ use Krinkle\Intuition\Intuition;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Process;
+use Symfony\Contracts\Cache\CacheInterface;
 
 /**
  * @author Thomas Pellissier Tanon
@@ -96,11 +97,15 @@ class ConvertGenerator implements FormatGenerator {
 	/** @var int Command timeout in seconds. */
 	private $timeout;
 
-	public function __construct( FontProvider $fontProvider, Api $api, Intuition $intuition, int $timeout ) {
+	/** @var CacheInterface */
+	private $cache;
+
+	public function __construct( FontProvider $fontProvider, Api $api, Intuition $intuition, int $timeout, CacheInterface $cache ) {
 		$this->fontProvider = $fontProvider;
 		$this->api = $api;
 		$this->intuition = $intuition;
 		$this->timeout = $timeout;
+		$this->cache = $cache;
 	}
 
 	/**
@@ -152,7 +157,7 @@ class ConvertGenerator implements FormatGenerator {
 	}
 
 	private function createEpub( Book $book ) {
-		$epubGenerator = new EpubGenerator( $this->fontProvider, $this->api, $this->intuition );
+		$epubGenerator = new EpubGenerator( $this->fontProvider, $this->api, $this->intuition, $this->cache );
 		return $epubGenerator->create( $book );
 	}
 

--- a/src/GeneratorSelector.php
+++ b/src/GeneratorSelector.php
@@ -9,6 +9,7 @@ use App\Generator\FormatGenerator;
 use App\Util\Api;
 use Exception;
 use Krinkle\Intuition\Intuition;
+use Symfony\Contracts\Cache\CacheInterface;
 
 class GeneratorSelector {
 
@@ -47,11 +48,15 @@ class GeneratorSelector {
 	/** @var Intuition */
 	private $intuition;
 
-	public function __construct( FontProvider $fontProvider, Api $api, ConvertGenerator $convertGenerator, Intuition $intuition ) {
+	/** @var CacheInterface */
+	private $cache;
+
+	public function __construct( FontProvider $fontProvider, Api $api, ConvertGenerator $convertGenerator, Intuition $intuition, CacheInterface $cache ) {
 		$this->fontProvider = $fontProvider;
 		$this->api = $api;
 		$this->convertGenerator = $convertGenerator;
 		$this->intuition = $intuition;
+		$this->cache = $cache;
 	}
 
 	/**
@@ -74,7 +79,7 @@ class GeneratorSelector {
 			$format = self::$aliases[$format];
 		}
 		if ( $format === 'epub-3' ) {
-			return new EpubGenerator( $this->fontProvider, $this->api, $this->intuition );
+			return new EpubGenerator( $this->fontProvider, $this->api, $this->intuition, $this->cache );
 		} elseif ( in_array( $format, ConvertGenerator::getSupportedTypes() ) ) {
 			$this->convertGenerator->setFormat( $format );
 			return $this->convertGenerator;

--- a/src/Refresh.php
+++ b/src/Refresh.php
@@ -3,7 +3,6 @@
 namespace App;
 
 use App\Util\Api;
-use Exception;
 use Psr\Cache\CacheItemPoolInterface;
 
 class Refresh {
@@ -24,24 +23,11 @@ class Refresh {
 			mkdir( $this->getTempFileName( '' ) );
 		}
 
-		$this->getEpubCssWikisource();
 		$this->cacheItemPool->deleteItems( [
 			'namespaces_' . $this->api->getLang(),
 			'about_' . $this->api->getLang(),
+			'css_' . $this->api->getLang(),
 		] );
-	}
-
-	protected function getEpubCssWikisource() {
-		$content = file_get_contents( dirname( __DIR__ ) . '/resources/styles/mediawiki.css' );
-		try {
-			$content .= "\n" . $this->api->get( 'https://' . $this->api->getLang() . '.wikisource.org/w/index.php?title=MediaWiki:Epub.css&action=raw&ctype=text/css' );
-		} catch ( Exception $e ) {
-		}
-		$this->setTempFileContent( 'epub.css', $content );
-	}
-
-	protected function setTempFileContent( $name, $content ) {
-		return file_put_contents( $this->getTempFileName( $name ), $content );
 	}
 
 	protected function getTempFileName( $name ) {

--- a/tests/Book/GeneratorSelectorTest.php
+++ b/tests/Book/GeneratorSelectorTest.php
@@ -33,11 +33,12 @@ class GeneratorSelectorTest extends KernelTestCase {
 	public function setUp(): void {
 		parent::setUp();
 		self::bootKernel();
-		$this->fontProvider = new FontProvider( new ArrayAdapter(), self::$container->get( OnWikiConfig::class ) );
+		$cache = new ArrayAdapter();
+		$this->fontProvider = new FontProvider( $cache, self::$container->get( OnWikiConfig::class ) );
 		$this->api = self::$container->get( Api::class );
 		$this->intuition = self::$container->get( Intuition::class );
-		$convertGenerator = new ConvertGenerator( $this->fontProvider, $this->api, $this->intuition, 10 );
-		$this->generatorSelector = new GeneratorSelector( $this->fontProvider, $this->api, $convertGenerator, $this->intuition );
+		$convertGenerator = new ConvertGenerator( $this->fontProvider, $this->api, $this->intuition, 10, $cache );
+		$this->generatorSelector = new GeneratorSelector( $this->fontProvider, $this->api, $convertGenerator, $this->intuition, $cache );
 	}
 
 	public function testGetUnknownGeneratorRaisesException() {

--- a/tests/BookCreator/BookCreatorIntegrationTest.php
+++ b/tests/BookCreator/BookCreatorIntegrationTest.php
@@ -40,11 +40,12 @@ class BookCreatorIntegrationTest extends KernelTestCase {
 
 	public function setUp(): void {
 		self::bootKernel();
-		$this->fontProvider = new FontProvider( new ArrayAdapter(), self::$container->get( OnWikiConfig::class ) );
+		$cache = new ArrayAdapter();
+		$this->fontProvider = new FontProvider( $cache, self::$container->get( OnWikiConfig::class ) );
 		$this->api = self::$container->get( Api::class );
 		$this->intuition = self::$container->get( Intuition::class );
-		$convertGenerator = new ConvertGenerator( $this->fontProvider, $this->api, $this->intuition, 10 );
-		$this->generatorSelector = new GeneratorSelector( $this->fontProvider, $this->api, $convertGenerator, $this->intuition );
+		$convertGenerator = new ConvertGenerator( $this->fontProvider, $this->api, $this->intuition, 10, $cache );
+		$this->generatorSelector = new GeneratorSelector( $this->fontProvider, $this->api, $convertGenerator, $this->intuition, $cache );
 		$this->creditRepository = self::$container->get( CreditRepository::class );
 		$this->epubCheck = self::$container->get( EpubCheck::class );
 	}


### PR DESCRIPTION
This switches the caching, but doesn't fully clean up a few other
things; they'll come in a later patch.

Bug: https://phabricator.wikimedia.org/T273832