### PR TITLE
Docker: allow configuration of port

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,11 @@ echo "WS_DOCKER_UID=$(id -u)
 WS_DOCKER_GID=$(id -g)" >> ./.env
 ```
 
+Optionally, set the port in `.env` (default is 8888):
+```bash
+WS_EXPORT_PORT=18000
+```
+
 Start the environment and install
 
 ```bash
@@ -131,7 +136,7 @@ docker-compose exec wsexport composer install
 docker-compose exec wsexport ./bin/console doctrine:migrations:migrate --no-interaction
 ```
 
-Wikisource Export should be up at http://localhost:8888/
+Wikisource Export should be up at http://localhost:8888/ (or the configured port)
 
 ### Cache
 Go to `/refresh` to clear the cache

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
         USER_ID: ${WS_DOCKER_UID}
         GROUP_ID: ${WS_DOCKER_GID}
     ports:
-      - "8888:8080"
+      - "${WS_EXPORT_PORT:-8888}:8080"
     extra_hosts:
       - "host.docker.internal:host-gateway"  
     volumes:


### PR DESCRIPTION
If you have another server on port 8888, this allows
you to set WS_EXPORT_PORT in .env and change the WS Export
server port.