### PR TITLE
Avoid non-numeric year and months for stats query

### DIFF
--- a/src/Repository/GeneratedBookRepository.php
+++ b/src/Repository/GeneratedBookRepository.php
@@ -40,6 +40,12 @@ class GeneratedBookRepository extends ServiceEntityRepository {
 	 * @return int[][] Total counts, keyed by format and then language code.
 	 */
 	public function getTypeAndLangStats( string $month, string $year ): array {
+		if ( !is_numeric( $month ) ) {
+			$month = null;
+		}
+		if ( !is_numeric( $year ) ) {
+			$year = null;
+		}
 		$sql = 'SELECT `format`, `lang`, COUNT(1) AS `number` '
 			. ' FROM books_generated'
 			. ' WHERE YEAR(`time`) = :year AND MONTH(`time`) = :month'


### PR DESCRIPTION
This is to avoid confusion because MySQL casts a string starting
with a number to that number, when comparing to the output of MONTH()
etc.

Bug: https://phabricator.wikimedia.org/T290674