### PR TITLE
Escape exception parameters on display

### DIFF
--- a/templates/export.html.twig
+++ b/templates/export.html.twig
@@ -21,7 +21,7 @@
 			</button>
 			<p class="message-inner">
 				<strong>{{ msg( 'export-failed' ) }}</strong>
-				<span>{{ msg( exception.i18nMessage, exception.i18nParams ) }}</span>
+				<span>{{ msg( exception.i18nMessage, exception.i18nParams|map(p => p|escape ) ) }}</span>
 				{% if exception.friendly %}
 					{# Friendly errors show a 'Learn more' link with troubleshooting tips. #}
 					<button id="learn-more-link" type="button" role="button" data-toggle="collapse" class="btn btn-link alert-link"


### PR DESCRIPTION
HTML-escape all parameters to exceptions, when they're displayed
on the export page.

Bug: https://phabricator.wikimedia.org/T290674