### PR TITLE
Don't link to non-existent wiki lang

### DIFF
--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -118,6 +118,7 @@ class ExportController extends AbstractController {
 			'formats' => GeneratorSelector::getValidFormats(),
 			'format' => $this->getFormat( $request ),
 			'title' => $this->getTitle( $request ),
+			'wikiLangs' => $this->wikidata->getWikisourceLangs( $this->intuition->getLang() );
 			'langs' => $this->getLangs( $request ),
 			'lang' => $this->getLang( $request ),
 			'credits' => $credits,

--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -118,7 +118,7 @@ class ExportController extends AbstractController {
 			'formats' => GeneratorSelector::getValidFormats(),
 			'format' => $this->getFormat( $request ),
 			'title' => $this->getTitle( $request ),
-			'wikiLangs' => $this->wikidata->getWikisourceLangs( $this->intuition->getLang() );
+			'wikiLangs' => $this->wikidata->getWikisourceLangs( $this->intuition->getLang() ),
 			'langs' => $this->getLangs( $request ),
 			'lang' => $this->getLang( $request ),
 			'credits' => $credits,

--- a/templates/export.html.twig
+++ b/templates/export.html.twig
@@ -3,7 +3,7 @@
 {% block main %}
 
 <p class="back-to-wikisource">
-	<a href="https://{% if lang in wikiLangs %}{{ lang }}.{% endif %}wikisource.org{% if title %}/wiki/{{ title|e('url') }}{% endif %}">
+	<a href="https://{% if lang in wikiLangs|keys %}{{ lang }}.{% endif %}wikisource.org{% if title %}/wiki/{{ title|e('url') }}{% endif %}">
 		{# Arrow is from OOUI. #}
 		<img src="/img/previous-{% if is_rtl() %}rtl{% else %}ltr{% endif %}.svg" alt="{{ msg('previous-alt-text') }}" width="20" height="20" />
 		<span>{{ msg('back-to-wikisource') }}</span>

--- a/templates/export.html.twig
+++ b/templates/export.html.twig
@@ -3,7 +3,7 @@
 {% block main %}
 
 <p class="back-to-wikisource">
-	<a href="https://{% if lang in langs %}{{ lang }}.{% endif %}wikisource.org{% if title %}/wiki/{{ title|e('url') }}{% endif %}">
+	<a href="https://{% if lang in wikiLangs %}{{ lang }}.{% endif %}wikisource.org{% if title %}/wiki/{{ title|e('url') }}{% endif %}">
 		{# Arrow is from OOUI. #}
 		<img src="/img/previous-{% if is_rtl() %}rtl{% else %}ltr{% endif %}.svg" alt="{{ msg('previous-alt-text') }}" width="20" height="20" />
 		<span>{{ msg('back-to-wikisource') }}</span>

--- a/templates/export.html.twig
+++ b/templates/export.html.twig
@@ -3,7 +3,7 @@
 {% block main %}
 
 <p class="back-to-wikisource">
-	<a href="https://{% if lang %}{{ lang }}.{% endif %}wikisource.org{% if title %}/wiki/{{ title|e('url') }}{% endif %}">
+	<a href="https://{% if lang in langs|keys %}{{ lang }}.{% endif %}wikisource.org{% if title %}/wiki/{{ title|e('url') }}{% endif %}">
 		{# Arrow is from OOUI. #}
 		<img src="/img/previous-{% if is_rtl() %}rtl{% else %}ltr{% endif %}.svg" alt="{{ msg('previous-alt-text') }}" width="20" height="20" />
 		<span>{{ msg('back-to-wikisource') }}</span>

--- a/templates/export.html.twig
+++ b/templates/export.html.twig
@@ -3,7 +3,7 @@
 {% block main %}
 
 <p class="back-to-wikisource">
-	<a href="https://{% if lang in langs|keys %}{{ lang }}.{% endif %}wikisource.org{% if title %}/wiki/{{ title|e('url') }}{% endif %}">
+	<a href="https://{% if lang in langs %}{{ lang }}.{% endif %}wikisource.org{% if title %}/wiki/{{ title|e('url') }}{% endif %}">
 		{# Arrow is from OOUI. #}
 		<img src="/img/previous-{% if is_rtl() %}rtl{% else %}ltr{% endif %}.svg" alt="{{ msg('previous-alt-text') }}" width="20" height="20" />
 		<span>{{ msg('back-to-wikisource') }}</span>


### PR DESCRIPTION
We already know that we don't want to link to a lang if it's not set, so this just makes it more specific. It must be set and must exist in the area of existing wiki langs.