### PR TITLE
Atom: Makes sure to escape '&'

### DIFF
--- a/src/Generator/AtomGenerator.php
+++ b/src/Generator/AtomGenerator.php
@@ -120,7 +120,7 @@ class AtomGenerator implements FormatGenerator {
 			return;
 		}
 
-		$node = $dom->createElement( $name, $value );
+		$node = $dom->createElement( $name, str_replace( '&', '&amp;', $value ) );
 
 		if ( $type !== '' ) {
 			$node->setAttribute( 'xsi:type', $type );


### PR DESCRIPTION
DOMDocument::createElement escapes '<' and '>' but not '&'...