### PR TITLE
AtomGenerator: use native XML escape

### DIFF
--- a/src/Generator/AtomGenerator.php
+++ b/src/Generator/AtomGenerator.php
@@ -120,7 +120,8 @@ class AtomGenerator implements FormatGenerator {
 			return;
 		}
 
-		$node = $dom->createElement( $name, str_replace( '&', '&amp;', $value ) );
+		$node = $dom->createElement( $name );
+		$node->textContent = $value;
 
 		if ( $type !== '' ) {
 			$node->setAttribute( 'xsi:type', $type );


### PR DESCRIPTION
Let's rely on the std functions instead of hacking ours.