### PR TITLE
Add missing author names to toolinfo.json

### DIFF
--- a/public/toolinfo.json
+++ b/public/toolinfo.json
@@ -4,6 +4,16 @@
 	"description" : "Export Wikisource books in many file formats.",
 	"url" : "https://wsexport.toolforge.org/tool/book.php",
 	"keywords" : "Wikisource, books, ebooks, ePub, PDF",
-	"author" : "Tpt",
+	"author" : [
+		{"name": "Tpt"},
+		{"name": "Sam Wilson"},
+		{"name": "MusikAnimal"},
+		{"name": "Dayllan Maza"},
+		{"name": "Jan Berkel"},
+		{"name": "phil-el"},
+		{"name": "cimurah"},
+		{"name": "Max Semenik"},
+		{"name": "Daimona"}
+	],
 	"repository" : "https://github.com/wsexport/tool"
 }


### PR DESCRIPTION
These names were the result of the following command:

git log --format='{"name": "%aN"},' | sort |  uniq -c | sort -nr