### PR TITLE
Add OpenDyslexic font

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Install Calibre, epubcheck, and fonts
       run: |
         sudo apt-get update -q
-        sudo apt-get install fonts-freefont-ttf fonts-linuxlibertine fonts-dejavu-core fonts-gubbi libegl1 libopengl0 -y
+        sudo apt-get install fonts-freefont-ttf fonts-linuxlibertine fonts-dejavu-core fonts-gubbi fonts-opendyslexic libegl1 libopengl0 -y
         sudo mkdir /usr/share/desktop-directories/
         sudo -v && wget -nv -O- https://download.calibre-ebook.com/linux-installer.sh | sudo sh /dev/stdin
         wget https://github.com/w3c/epubcheck/releases/download/v4.2.4/epubcheck-4.2.4.zip

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Requirements
 * PHP 7.3 or 7.4
 * [Composer](http://getcomposer.org/)
 * The `fc-list` command
-* The following fonts:
+* The following fonts (optional, but required for development):
   * `fonts-freefont-ttf`
   * `fonts-linuxlibertine`
   * `fonts-dejavu-core`

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Requirements
 * PHP 7.3 or 7.4
 * [Composer](http://getcomposer.org/)
 * The `fc-list` command
+* The following fonts:
+  * `fonts-freefont-ttf`
+  * `fonts-linuxlibertine`
+  * `fonts-dejavu-core`
+  * `fonts-gubbi`
+  * `fonts-opendyslexic`
 
 Installation
 ============

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update -q && apt-get install -y \
         fonts-linuxlibertine \
         fonts-dejavu-core \
         fonts-gubbi \
+        fonts-opendyslexic \
         git \
         libzip-dev \
         libicu-dev \

--- a/tests/FontProviderTest.php
+++ b/tests/FontProviderTest.php
@@ -78,13 +78,13 @@ body { font-family: "Linux Libertine O" }
 body { font-family: "Gubbi" }
 ', $this->fontProvider->getCss( 'Gubbi' ) );
 
-		$this->assertSame('@font-face {  font-family: "OpenDyslexic";  font-weight: normal;  font-style: normal;  src: url("fonts/OpenDyslexic-Regular.woff");}
+		$this->assertSame( '@font-face {  font-family: "OpenDyslexic";  font-weight: normal;  font-style: normal;  src: url("fonts/OpenDyslexic-Regular.woff");}
 @font-face {  font-family: "OpenDyslexic";  font-weight: 800;  font-style: normal;  src: url("fonts/OpenDyslexic-Bold.woff");}
 @font-face {  font-family: "OpenDyslexic";  font-weight: normal;  font-style: italic;  src: url("fonts/OpenDyslexic-Italic.woff");}
 @font-face {  font-family: "OpenDyslexic";  font-weight: 800;  font-style: italic;  src: url("fonts/OpenDyslexic-BoldItalic.woff");}
 body { font-family: "OpenDyslexic" }
 ',
-		$this->fontProvider->getCss( 'OpenDyslexic' ));
+		$this->fontProvider->getCss( 'OpenDyslexic' ) );
 
 		$this->assertSame( '', $this->fontProvider->getCss( 'invalid-font-name' ) );
 	}

--- a/tests/FontProviderTest.php
+++ b/tests/FontProviderTest.php
@@ -39,6 +39,7 @@ class FontProviderTest extends TestCase {
 			[ 'freeserif', 'FreeSerif' ],
 			[ 'dejavu-sans', 'DejaVu Sans' ],
 			[ 'linuxlibertine', 'Linux Libertine O' ],
+            [ 'opendyslexic', 'OpenDyslexic' ]
 		];
 	}
 
@@ -76,6 +77,14 @@ body { font-family: "Linux Libertine O" }
 		$this->assertSame( '@font-face {  font-family: "Gubbi";  font-weight: normal;  font-style: normal;  src: url("fonts/Gubbi.ttf");}
 body { font-family: "Gubbi" }
 ', $this->fontProvider->getCss( 'Gubbi' ) );
+
+        $this->assertSame('@font-face {  font-family: "OpenDyslexic";  font-weight: normal;  font-style: normal;  src: url("fonts/OpenDyslexic-Regular.woff");}
+@font-face {  font-family: "OpenDyslexic";  font-weight: 800;  font-style: normal;  src: url("fonts/OpenDyslexic-Bold.woff");}
+@font-face {  font-family: "OpenDyslexic";  font-weight: normal;  font-style: italic;  src: url("fonts/OpenDyslexic-Italic.woff");}
+@font-face {  font-family: "OpenDyslexic";  font-weight: 800;  font-style: italic;  src: url("fonts/OpenDyslexic-BoldItalic.woff");}
+body { font-family: "OpenDyslexic" }
+',
+        $this->fontProvider->getCss( 'OpenDyslexic' ));
 
 		$this->assertSame( '', $this->fontProvider->getCss( 'invalid-font-name' ) );
 	}

--- a/tests/FontProviderTest.php
+++ b/tests/FontProviderTest.php
@@ -39,7 +39,7 @@ class FontProviderTest extends TestCase {
 			[ 'freeserif', 'FreeSerif' ],
 			[ 'dejavu-sans', 'DejaVu Sans' ],
 			[ 'linuxlibertine', 'Linux Libertine O' ],
-            [ 'opendyslexic', 'OpenDyslexic' ]
+			[ 'opendyslexic', 'OpenDyslexic' ]
 		];
 	}
 
@@ -78,13 +78,13 @@ body { font-family: "Linux Libertine O" }
 body { font-family: "Gubbi" }
 ', $this->fontProvider->getCss( 'Gubbi' ) );
 
-        $this->assertSame('@font-face {  font-family: "OpenDyslexic";  font-weight: normal;  font-style: normal;  src: url("fonts/OpenDyslexic-Regular.woff");}
+		$this->assertSame('@font-face {  font-family: "OpenDyslexic";  font-weight: normal;  font-style: normal;  src: url("fonts/OpenDyslexic-Regular.woff");}
 @font-face {  font-family: "OpenDyslexic";  font-weight: 800;  font-style: normal;  src: url("fonts/OpenDyslexic-Bold.woff");}
 @font-face {  font-family: "OpenDyslexic";  font-weight: normal;  font-style: italic;  src: url("fonts/OpenDyslexic-Italic.woff");}
 @font-face {  font-family: "OpenDyslexic";  font-weight: 800;  font-style: italic;  src: url("fonts/OpenDyslexic-BoldItalic.woff");}
 body { font-family: "OpenDyslexic" }
 ',
-        $this->fontProvider->getCss( 'OpenDyslexic' ));
+		$this->fontProvider->getCss( 'OpenDyslexic' ));
 
 		$this->assertSame( '', $this->fontProvider->getCss( 'invalid-font-name' ) );
 	}


### PR DESCRIPTION
Per request on the French Wikisource, it was asked that WSExport had a dyslexic-friendly font (see https://fr.wikisource.org/wiki/Wikisource:Scriptorium/Mars_2023#Police_pour_dyslexique_en_export). I thus added OpenDyslexic to the requirements and updated the tests and documentation to mirror this.