### PR TITLE
Apply coding standards to bin/console

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -2,46 +2,47 @@
 <?php
 
 use App\Kernel;
+use Samwilson\ConsoleReadmeGenerator\Command\ReadmeGenCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\ErrorHandler\Debug;
-use Samwilson\ConsoleReadmeGenerator\Command\ReadmeGenCommand;
 
-if (!in_array(PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
-    echo 'Warning: The console should be invoked via the CLI version of PHP, not the '.PHP_SAPI.' SAPI'.PHP_EOL;
+if ( !in_array( PHP_SAPI, [ 'cli', 'phpdbg', 'embed' ], true ) ) {
+	echo 'Warning: The console should be invoked via the CLI version of PHP, not the ' . PHP_SAPI . ' SAPI' . PHP_EOL;
 }
 
-set_time_limit(0);
+set_time_limit( 0 );
 
-require dirname(__DIR__).'/vendor/autoload.php';
+require dirname( __DIR__ ) . '/vendor/autoload.php';
 
-if (!class_exists(Application::class) || !class_exists(Dotenv::class)) {
-    throw new LogicException('You need to add "symfony/framework-bundle" and "symfony/dotenv" as Composer dependencies.');
+if ( !class_exists( Application::class ) || !class_exists( Dotenv::class ) ) {
+	throw new LogicException( 'You need to add "symfony/framework-bundle" and "symfony/dotenv" as Composer dependencies.' );
 }
 
 $input = new ArgvInput();
-if (null !== $env = $input->getParameterOption(['--env', '-e'], null, true)) {
-    putenv('APP_ENV='.$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $env);
+$env = $input->getParameterOption( [ '--env', '-e' ], null, true );
+if ( $env !== null ) {
+	putenv( 'APP_ENV=' . $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $env );
 }
 
-if ($input->hasParameterOption('--no-debug', true)) {
-    putenv('APP_DEBUG='.$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = '0');
+if ( $input->hasParameterOption( '--no-debug', true ) ) {
+	putenv( 'APP_DEBUG=' . $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = '0' );
 }
 
-(new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
+( new Dotenv() )->bootEnv( dirname( __DIR__ ) . '/.env' );
 
-if ($_SERVER['APP_DEBUG']) {
-    umask(0000);
+if ( $_SERVER['APP_DEBUG'] ) {
+	umask( 0000 );
 
-    if (class_exists(Debug::class)) {
-        Debug::enable();
-    }
+	if ( class_exists( Debug::class ) ) {
+		Debug::enable();
+	}
 }
 
-$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
-$application = new Application($kernel);
+$kernel = new Kernel( $_SERVER['APP_ENV'], (bool)$_SERVER['APP_DEBUG'] );
+$application = new Application( $kernel );
 if ( class_exists( ReadmeGenCommand::class ) ) {
-    $application->add( new ReadmeGenCommand() );
+	$application->add( new ReadmeGenCommand() );
 }
-$application->run($input);
+$application->run( $input );

--- a/composer.json
+++ b/composer.json
@@ -92,6 +92,7 @@
 		"test": [
 			"composer validate",
 			"phpcs -s .",
+			"cat bin/console | ./vendor/bin/phpcs",
 			"@php ./bin/console lint:twig ./templates",
 			"@php ./bin/console lint:yaml ./config",
 			"minus-x check .",


### PR DESCRIPTION
phpcs doesn't handle extensionless files unless we want to check all, but it does support stdin so this just adds a separate command for testing this one file.