### PR TITLE
Fix T332112: replace deprecated function mb_convert_encoding()

### DIFF
--- a/src/Util/Util.php
+++ b/src/Util/Util.php
@@ -82,6 +82,7 @@ class Util {
 		return $html . '<body>' . $content . '</body></html>';
 	}
 
+	// Replace non-ASCII characters with ASCII equivalents.
 	public static function encodeString( $string ) {
 		static $map = [];
 		static $num = 0;

--- a/src/Util/Util.php
+++ b/src/Util/Util.php
@@ -97,7 +97,7 @@ class Util {
 		foreach ( $search as $i => $pat ) {
 			$map[$string] = mb_eregi_replace( $pat, $replace[$i], $map[$string] );
 		}
-		$map[$string] = 'c' . $num . '_' . static::cutFilename( mb_convert_encoding( $map[$string], 'ISO-8859-1', 'UTF-8' ) );
+		$map[$string] = 'c' . $num . '_' . static::cutFilename( iconv( 'UTF-8', 'ISO-8859-1//TRANSLIT', $map[$string] ) );
 		$num++;
 
 		return $map[$string];

--- a/tests/Util/UtilTest.php
+++ b/tests/Util/UtilTest.php
@@ -7,9 +7,15 @@ use PHPUnit\Framework\TestCase;
 
 class UtilTest extends TestCase {
 	/**
+	 * encodeString prefixes encoded strings with an incrementing counter
+	 * which we omit from the tests by using assertStringEndsWith().
+	 *
 	 * @covers ::encodeString
 	 */
 	public function testEncodeString() {
-		 $this->assertStringEndsWith( '_test_dou', Util::encodeString( 'test_Δôü' ) );
+		$this->assertStringEndsWith( '_test_dou', Util::encodeString( 'test_Δôü' ) );
+		$this->assertStringEndsWith( '_foo', Util::encodeString( 'foo' ) );
+		$this->assertStringEndsWith( '_._____', Util::encodeString( '.-!:?$' ) );
+		$this->assertStringEndsWith( '__', Util::encodeString( '🎉' ) );
 	}
 }


### PR DESCRIPTION
- Add more tests for Util::encodeString, to improve confidence that the new implementation doesn't break the old behavior
- Fix [T332112](https://phabricator.wikimedia.org/T332112): replace deprecated function mb_convert_encoding() with iconv()
