### PR TITLE
Remove default-style directive as unneeded

### DIFF
--- a/src/Util/Util.php
+++ b/src/Util/Util.php
@@ -74,7 +74,7 @@ class Util {
 		if ( $lang != null ) {
 			$html .= ' xml:lang="' . $lang . '" dir="' . static::getLanguageDirection( $lang ) . '"';
 		}
-		$html .= '><head><meta charset="UTF-8" content="application/xhtml+xml;charset=UTF-8" http-equiv="default-style" /><link type="text/css" rel="stylesheet" href="main.css" /><title>' . $title . '</title></head>';
+		$html .= '><head><meta charset="UTF-8" /><link type="text/css" rel="stylesheet" href="main.css" /><title>' . $title . '</title></head>';
 
 		if ( $bodyPosition ) {
 			return $html . $content;


### PR DESCRIPTION
The http-equiv="default-style" directive is for providing the name of the default style (in the content attribute), but we're not using it. It also fails epubcheck's validation.

https://w3c.github.io/html-reference/meta.http-equiv.default-style.html