### PR TITLE
Redesign stats page

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -76,6 +76,5 @@
 	"breadcrumbs-home-link": "Home",
 	"breadcrumbs-stats-link": "Statistics",
 	"recently-popular-heading": "Recently popular",
-	"recently-popular-subtext": "Most popular downloads from the last three months",
-	"stat-date-label": "Showing stats for"
+	"recently-popular-subtext": "Most popular downloads from the last three months"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -72,5 +72,10 @@
 	"exception-book-conversion": "Error converting the format of the book.",
 	"epub-title-page": "Title page",
 	"epub-exported-date": "Exported from Wikisource on $1",
-	"epub-about": "About"
+	"epub-about": "About",
+	"breadcrumbs-home-link": "Home",
+	"breadcrumbs-stats-link": "Statistics",
+	"recently-popular-heading": "Recently popular",
+	"recently-popular-subtext": "Most popular downloads from the last three months",
+	"stat-date-label": "Showing stats for"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -78,5 +78,10 @@
 	"exception-book-conversion": "Error message displayed when a book could not be converted to another format.",
 	"epub-title-page": "Name of the title page in exported books (used in the table of contents).",
 	"epub-exported-date": "Phrase used on the title page to indicate the book export date.\n\n$1 - the localized date.",
-	"epub-about": "Name of the 'about' page in exported books (used in the table of contents)."
+	"epub-about": "Name of the 'about' page in exported books (used in the table of contents).",
+	"breadcrumbs-home-link": "Link of home page shown in the breadcrumb",
+	"breadcrumbs-stats-link": "Link of statistics page shown in the breadcrumb",
+	"recently-popular-heading": "Heading text for recently popular section",
+	"recently-popular-subtext": "Description for recently popular section",
+	"stat-date-label": "Label text for stat dates"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -82,6 +82,5 @@
 	"breadcrumbs-home-link": "Link of home page shown in the breadcrumb",
 	"breadcrumbs-stats-link": "Link of statistics page shown in the breadcrumb",
 	"recently-popular-heading": "Heading text for recently popular section",
-	"recently-popular-subtext": "Description for recently popular section",
-	"stat-date-label": "Label text for stat dates"
+	"recently-popular-subtext": "Description for recently popular section"
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -28,6 +28,7 @@ footer {
 	font-size: smaller;
 	border-top: 1px solid #e5e5e5;
 	padding: 25px 0;
+	margin-top: 2rem;
 }
 
 footer p {
@@ -114,4 +115,68 @@ div.error > .message {
 
 div.error p {
 	margin: 0;
+}
+
+.stats {
+	padding: 0 1.5rem;
+}
+
+.recents {
+	background-color: #f5f5f5;
+	border-radius: 2px;
+	padding: 1.5rem 2rem;
+}
+
+.recents h1,
+.recents h4 {
+	margin: 0;
+}
+
+.recents h4 {
+	margin-top: 2px;
+}
+
+.recents ol {
+	margin-top: 3rem;
+	padding: 0;
+}
+
+.recents ol li {
+	list-style: none;
+}
+
+.recent {
+	margin: 0 auto;
+	padding-top: 15px;
+}
+
+.recent:not( :last-child ) {
+	border-bottom: 1px solid #d9d9d9;
+	padding-bottom: 15px;
+}
+
+.recent div {
+	padding: 0;
+}
+
+.recent h4,
+.recent h3 {
+	margin: 0;
+}
+
+.recent h3 {
+	margin-top: 5px;
+}
+
+.recent div:nth-child( 2 ) {
+	display: flex;
+	height: 50px;
+	padding-right: 5px;
+	align-items: center;
+	justify-content: flex-end;
+}
+
+.recent img {
+	height: 25px;
+	width: 25px;
 }

--- a/templates/_month_year_selector.html.twig
+++ b/templates/_month_year_selector.html.twig
@@ -1,0 +1,15 @@
+<form class="form-inline" role="form">
+	<div class="form-group">
+		<label class="sr-only" for="month">Month</label>
+		<div class="input-group">
+			<div class="input-group-addon">Month</div>
+			<input name="month" id="month" type="number" placeholder="month" size="2" maxlength="2" min="1" max="12" required="required" value="{{ month }}" class="form-control">
+		</div>
+		<label class="sr-only" for="year">Year</label>
+		<div class="input-group">
+			<div class="input-group-addon">Year</div>
+			<input name="year" id="year" type="number" placeholder="year" size="4" maxlength="4" min="2012" required="required" value="{{ year }}" class="form-control">
+		</div>
+	</div>
+	<button type="submit" class="btn btn-primary">Fetch stats</button>
+</form>

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -29,12 +29,13 @@
 	</div>
 </header>
 
-<div class="container">
+<div>
 	<div class="content">
 		{% block main %}
 		{% endblock %}
 
 		<footer class="footer">
+		<div class="container">
 			<p>
 				{% set version_link %}
 					<a href="https://github.com/wikimedia/ws-export/releases/tag/{{ git_tag() }}" title="{{ msg( 'commit-label', [ git_hash_short() ] ) }}">
@@ -74,6 +75,7 @@
 					{{ msg( 'issue-button' ) }}
 				</a>
 			</p>
+		</div>
 		</footer>
 	</div>
 </div>

--- a/templates/export.html.twig
+++ b/templates/export.html.twig
@@ -1,7 +1,7 @@
 {% extends 'base.html.twig' %}
 
 {% block main %}
-
+<div class="container">
 <p class="back-to-wikisource">
 	<a href="https://{% if lang in wikiLangs|keys %}{{ lang }}.{% endif %}wikisource.org{% if title %}/wiki/{{ title|e('url') }}{% endif %}">
 		{# Arrow is from OOUI. #}
@@ -119,5 +119,5 @@
 	</p>
 
 </form>
-
+</div>
 {% endblock %}

--- a/templates/statistics.html.twig
+++ b/templates/statistics.html.twig
@@ -41,7 +41,7 @@
 		<div class="col-md-8">
 			{% include '_month_year_selector.html.twig' with {month: month, year: year} %}
 			<table class="table table-striped">
-				<caption>{{ msg('stat-date-label') }} {{ month }}/{{ year }}</caption>
+				<caption>Stats for {{ month }}/{{ year }}</caption>
 				<thead>
 					<tr>
 						<th scope="col">Language</th>

--- a/templates/statistics.html.twig
+++ b/templates/statistics.html.twig
@@ -2,76 +2,83 @@
 
 {% block main %}
 
-<ol class="breadcrumb">
-	<li><a href="{{ path('home') }}">Home</a></li>
-	<li class="active">Statistics</li>
-</ol>
-<div class="row">
-	<aside class="col-md-3">
-		<h2>Recently Popular</h2>
-		<ol>
-			{% for book in recently_popular %}
-				<li value="{{ book.total }}">
-					<a href="{{ path('home', { lang: book.lang, page: book.title } ) }}" title="Download epub">
-						<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/EPUB_silk_icon.svg/20px-EPUB_silk_icon.svg.png" alt="The epub logo."/>
-					</a>
-					<a href="https://{{ book.lang }}.wikisource.org/wiki/{{ book.title }}" title="View on Wikisource">
-						{{ book.title|replace({'_': ' '}) }}
-					</a>
-				</li>
-			{% endfor %}
-		</ol>
-	</aside>
-	<div class="col-md-9">
-		<table class="table table-striped">
-			<caption>Stats for {{ month }}/{{ year }}</caption>
-			<thead>
-			<tr>
-				<th scope="col">Lang</th>
-				{% for format,value in total %}
-					<th scope="col">{{ format }}</th>
-				{% endfor %}
-			</tr>
-			</thead>
-			<tbody>
-				{% for lang,temp in val %}
-					<tr>
-						<th scope="row">{{ lang }}</th>
-						{% for format,value in total %}
-							<td>
-								{% if attribute(temp, format) is defined %}
-									{{ attribute(temp, format) }}
+<div class="container-fluid">
+	<ol class="breadcrumb">
+		<li><a href="{{ path('home') }}">{{ msg('breadcrumbs-home-link') }}</a></li>
+		<li class="active">{{ msg('breadcrumbs-stats-link') }}</li>
+	</ol>
+	<div class="row stats">
+		<div class="col-md-4 recents">
+			<h1 class=""><strong>{{ msg('recently-popular-heading') }}</strong></h1>
+			<h4 class="text-muted">{{ msg('recently-popular-subtext') }}</h4>
+			<ol>
+				{% for book in recently_popular %}
+					<li class="recent row">
+						<div class="col-md-9">
+							<h4 class="text-muted">
+								{{ book.total }}
+								{% if book.total > 1 %}
+									downloads
 								{% else %}
-									0
-								{% endif %}
-							</td>
+									download
+   								{% endif %}
+							<h4>
+							<h3>
+								<a href="https://{{ book.lang }}.wikisource.org/wiki/{{ book.title }}" title="View on Wikisource">
+									{{ book.title|replace({'_': ' '}) }}
+								</a>
+							</h3>
+						</div>
+						<div class="col-md-3">
+							<a href="{{ path('home', { lang: book.lang, page: book.title } ) }}" title="Download epub">
+								<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/EPUB_silk_icon.svg/20px-EPUB_silk_icon.svg.png" alt="The epub logo."/>
+							</a>
+						</div>
+					</li>
+				{% endfor %}
+			</ol>
+		</div>
+		<div class="col-md-8">
+			{% include '_month_year_selector.html.twig' with {month: month, year: year} %}
+			<table class="table table-striped">
+				<caption>{{ msg('stat-date-label') }} {{ month }}/{{ year }}</caption>
+				<thead>
+					<tr>
+						<th scope="col">Language</th>
+						{% for format,value in total %}
+							<th scope="col">{{ format }} </th>
 						{% endfor %}
 					</tr>
-				{% endfor %}
-			</tbody>
-			<tfoot>
-				<tr>
-					<th scope="row">Total</th>
-					{% for format,value in total %}
-						<td>{{ value }}</td>
+				</thead>
+				<tbody>
+					{% for lang,temp in val %}
+						<tr>
+							<th scope="row">{{ lang }}</th>
+							{% for format,value in total %}
+								<td>
+									{% if attribute(temp, format) is defined %}
+										{{ attribute(temp, format) }}
+									{% else %}
+										0
+									{% endif %}
+								</td>
+							{% endfor %}
+						</tr>
 					{% endfor %}
-				</tr>
-			</tfoot>
-		</table>
-		<form class="form-inline" role="form">
-			<label>Change month:</label>
-
-			<div class="form-group">
-				<input name="month" id="month" type="number" placeholder="month" size="2" maxlength="2" min="1" max="12"
-					required="required" value="{{ month }}" class="form-control"/>
-			</div>
-			<div class="form-group">
-				<input name="year" id="year" type="number" placeholder="year" size="4" maxlength="4" min="2012"
-					required="required" value="{{ year }}" class="form-control"/>
-			</div>
-			<button class="btn" type="btn btn-default">Go</button>
-		</form>
+				</tbody>
+				<tfoot>
+					<tr>
+						<th scope="row">Total</th>
+						{% for format,value in total %}
+							<td>{{ value }}</td>
+						{% endfor %}
+					</tr>
+				</tfoot>
+			</table>
+			{% include '_month_year_selector.html.twig' with {month: month, year: year} %}
+		</div>
 	</div>
 </div>
+
 
 {% endblock %}


### PR DESCRIPTION
Redesign stats page to be cleaner and
convey stats in a better way with more
accessibility for year/month inputs.
Also added i18n for content on the page.

Bug: [T353737](https://phabricator.wikimedia.org/T353737)