### PR TITLE
Limit the concurrency when fetching pages

### DIFF
--- a/src/BookProvider.php
+++ b/src/BookProvider.php
@@ -193,16 +193,15 @@ class BookProvider {
 	 * @return Page[]
 	 */
 	protected function getPages( $pages ) {
-		$promises = [];
-
+		$pageTitles = [];
 		foreach ( $pages as $id => $page ) {
-			$promises[$id] = $this->api->getPageAsync( $page->title );
+			$pageTitles[$id] = $page->title;
 		}
-
+		$contents = $this->api->getPageBatch( $pageTitles );
 		foreach ( $pages as $id => $page ) {
-			$page->content = $this->domDocumentFromHtml( $promises[$id]->wait() );
+			$page->content = isset( $contents[$id] )
+				? $this->domDocumentFromHtml( $contents[$id] ) : null;
 		}
-
 		return $pages;
 	}
 


### PR DESCRIPTION
For a production test case, BookProvider::getPages() was opening 3492
concurrent connections to the Wikimedia servers. That exceeds the
default maxmimum file descriptor limit, and there is a risk that the
tool will be blocked by WMF sysadmins.

So, limit the concurrency to 10 connections.
