### PR TITLE
Fix issue with cleaning transcluded reference links

### DIFF
--- a/src/PageParser.php
+++ b/src/PageParser.php
@@ -442,8 +442,11 @@ class PageParser {
 
 	private function cleanReferenceLinks() {
 		$links = $this->xPath->query(
-			'//*[@typeof="mw:Extension/ref"]/a | //a[@rel="mw:referencedBy"]'
+			'//*[contains(@typeof,"mw:Extension/ref")]/a | //a[@rel="mw:referencedBy"]'
 		);
+		if ( !$links ) {
+			return;
+		}
 		foreach ( $links as $link ) {
 			$href = $link->getAttribute( 'href' );
 			$pos = strpos( $href, '#' );

--- a/tests/Book/PageParserTest.php
+++ b/tests/Book/PageParserTest.php
@@ -233,4 +233,25 @@ class PageParserTest extends TestCase {
 			],
 		];
 	}
+
+	/**
+	 * @dataProvider provideCleanReferenceLinks
+	 */
+	public function testCleanReferenceLinks( string $html, string $expected ) {
+		$pageParser1 = new PageParser( Util::buildDOMDocumentFromHtml( $html ) );
+		$this->assertStringContainsString( $expected, $pageParser1->getContent( false )->saveXML() );
+	}
+
+	public function provideCleanReferenceLinks() {
+		return [
+			'no links to clean' => [
+				'<sup><a href="./Page#fn"><span>[1]</span></a></sup>',
+				'<a href="./Page#fn">',
+			],
+			'ref that is also transcluded' => [
+				'<sup class="mw-ref reference" id="cite_ref-1" rel="dc:references" typeof="mw:Transclusion mw:Extension/ref"><a href="./Page#cite_note-1"><span class="mw-reflink-text">[1]</span></a></sup>',
+				'<a href="#cite_note-1">',
+			],
+		];
+	}
 }


### PR DESCRIPTION
This fixes two issues with the PageParser::cleanReferenceLinks() method: the first when there are no reference links found, the second the actual bug linked below. The `typeof` attribute can contain values other than 'mw:Extension/ref' but we were only checking for that one on its own. Switching to xPath contains() function fixes this.

Bug: T358965