### PR TITLE
Handle unqualified image src attrs

### DIFF
--- a/src/BookProvider.php
+++ b/src/BookProvider.php
@@ -169,6 +169,17 @@ class BookProvider {
 
 			$pictures = $this->getPicturesData( $pictures );
 		}
+		// Clean up the image URLs if they're protocol relative or only a path. This would probably be better in
+		// PageParser, but it doesn't have access to the domain name.
+		foreach ( $pictures as $pic ) {
+			$url = $pic->url;
+			if ( str_starts_with( $url, '//' ) ) {
+				$url = 'https:' . $url;
+			} elseif ( str_starts_with( $url, '/' ) ) {
+				$url = 'https://' . $this->api->getDomainName() . $url;
+			}
+			$pic->url = $url;
+		}
 		$book->pictures = $pictures;
 
 		return $book;
@@ -215,13 +226,6 @@ class BookProvider {
 		$requests = function () use ( $client, $pictures ) {
 			foreach ( $pictures as $picture ) {
 				$url = $picture->url;
-				// Clean up the URL if it's protocol relative or only a path.
-				if ( str_starts_with( $url, '//' ) ) {
-					$url = 'https:' . $url;
-				} elseif ( str_starts_with( $url, '/' ) ) {
-					// The PageParser doesn't have access to the domain name, so we add it in here.
-					$url = 'https://' . $this->api->getDomainName() . $url;
-				}
 				yield function () use ( $client, $url ) {
 					// We could use the 'sink' option here, but for https://github.com/Kevinrob/guzzle-cache-middleware/issues/82
 					// @phan-suppress-next-line PhanUndeclaredMethod Magic method not declared in the interface

--- a/src/BookProvider.php
+++ b/src/BookProvider.php
@@ -215,6 +215,13 @@ class BookProvider {
 		$requests = function () use ( $client, $pictures ) {
 			foreach ( $pictures as $picture ) {
 				$url = $picture->url;
+				// Clean up the URL if it's protocol relative or only a path.
+				if ( str_starts_with( $url, '//' ) ) {
+					$url = 'https:' . $url;
+				} elseif ( str_starts_with( $url, '/' ) ) {
+					// The PageParser doesn't have access to the domain name, so we add it in here.
+					$url = 'https://' . $this->api->getDomainName() . $url;
+				}
 				yield function () use ( $client, $url ) {
 					// We could use the 'sink' option here, but for https://github.com/Kevinrob/guzzle-cache-middleware/issues/82
 					// @phan-suppress-next-line PhanUndeclaredMethod Magic method not declared in the interface

--- a/src/PageParser.php
+++ b/src/PageParser.php
@@ -227,17 +227,9 @@ class PageParser {
 
 			$picture->name = $picture->title;
 		}
-		$picture->url = $this->resolveProtocolRelativeUrl( $url );
+		$picture->url = $url;
 
 		return $picture;
-	}
-
-	private function resolveProtocolRelativeUrl( $url ) {
-		if ( strpos( $url, '//' ) === 0 ) {
-			return 'https:' . $url;
-		} else {
-			return $url;
-		}
 	}
 
 	/**

--- a/tests/Book/BookProviderTest.php
+++ b/tests/Book/BookProviderTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Cache\Adapter\NullAdapter;
  * @covers BookProvider
  */
 class BookProviderTest extends TestCase {
-	private BookProvider $bookProvider;
+	private $bookProvider;
 	private $mockHandler;
 
 	public function setUp(): void {


### PR DESCRIPTION
Add the domain name to image src values that don't have one, to support WikiHiero. Also move the protocol-relative handling out of the PageParser so that it can go along with the new domain name adding in one place.

Bug: T354242