### PR TITLE
Move image URL fixing to where the URL is used

### DIFF
--- a/src/BookProvider.php
+++ b/src/BookProvider.php
@@ -222,6 +222,7 @@ class BookProvider {
 				} elseif ( str_starts_with( $url, '/' ) ) {
 					$url = 'https://' . $this->api->getDomainName() . $url;
 				}
+				$picture->url = $url;
 				yield function () use ( $client, $url ) {
 					// We could use the 'sink' option here, but for https://github.com/Kevinrob/guzzle-cache-middleware/issues/82
 					// @phan-suppress-next-line PhanUndeclaredMethod Magic method not declared in the interface

--- a/src/BookProvider.php
+++ b/src/BookProvider.php
@@ -169,17 +169,6 @@ class BookProvider {
 
 			$pictures = $this->getPicturesData( $pictures );
 		}
-		// Clean up the image URLs if they're protocol relative or only a path. This would probably be better in
-		// PageParser, but it doesn't have access to the domain name.
-		foreach ( $pictures as $pic ) {
-			$url = $pic->url;
-			if ( str_starts_with( $url, '//' ) ) {
-				$url = 'https:' . $url;
-			} elseif ( str_starts_with( $url, '/' ) ) {
-				$url = 'https://' . $this->api->getDomainName() . $url;
-			}
-			$pic->url = $url;
-		}
 		$book->pictures = $pictures;
 
 		return $book;
@@ -226,6 +215,13 @@ class BookProvider {
 		$requests = function () use ( $client, $pictures ) {
 			foreach ( $pictures as $picture ) {
 				$url = $picture->url;
+				// Clean up the image URLs if they're protocol relative or only a path. This would probably be better in
+				// PageParser, but it doesn't have access to the domain name.
+				if ( str_starts_with( $url, '//' ) ) {
+					$url = 'https:' . $url;
+				} elseif ( str_starts_with( $url, '/' ) ) {
+					$url = 'https://' . $this->api->getDomainName() . $url;
+				}
 				yield function () use ( $client, $url ) {
 					// We could use the 'sink' option here, but for https://github.com/Kevinrob/guzzle-cache-middleware/issues/82
 					// @phan-suppress-next-line PhanUndeclaredMethod Magic method not declared in the interface

--- a/tests/Cli/BookCliTest.php
+++ b/tests/Cli/BookCliTest.php
@@ -13,7 +13,7 @@ class BookCliTest extends TestCase {
 		return [
 			[ 'The_Kiss_and_its_History', 'en' ],
 			[ 'Les_Fleurs_du_mal', 'fr' ],
-			[ 'Stelae of Naukratis', 'mul' ],
+			[ 'Stelae_of_Naukratis', 'mul' ],
 		];
 	}
 

--- a/tests/Cli/BookCliTest.php
+++ b/tests/Cli/BookCliTest.php
@@ -12,7 +12,8 @@ class BookCliTest extends TestCase {
 	public function bookProvider() {
 		return [
 			[ 'The_Kiss_and_its_History', 'en' ],
-			[ 'Les_Fleurs_du_mal', 'fr' ]
+			[ 'Les_Fleurs_du_mal', 'fr' ],
+			[ 'Stelae of Naukratis', 'mul' ],
 		];
 	}
 


### PR DESCRIPTION
The change I made in #513 fixed the URLs after they were used
to fetch the images! This moves that same logic to the location
in which it'll actually work. Sorry for the noise!

Bug: T354242