### PR TITLE
Check for imageinfo rather than missing or invalid

### DIFF
--- a/src/BookProvider.php
+++ b/src/BookProvider.php
@@ -304,10 +304,9 @@ class BookProvider {
 			'iiurlwidth' => $width,
 			'formatversion' => 2,
 		] )->wait();
-		// Give up for invalid cover titles or those that do not exist.
+		// Give up if no imageinfo is returned (e.g. invalid or missing title).
 		if ( !isset( $response['query']['pages'] )
-			|| isset( $response['query']['pages'][0]['missing'] )
-			|| isset( $response['query']['pages'][0]['invalid'] )
+			|| !isset( $response['query']['pages'][0]['imageinfo'][0] )
 		) {
 			return null;
 		}


### PR DESCRIPTION
Because shared-repo images are reported as missing, do not check for that status. And to make things simpler, use the same handling for invalid ones as well, and just check to see if any imageinfo metadata has been returned (that's all we're interested in, after all).

This is a follow-up to GH #512.

Bug: T372956