### PR TITLE
Remove Request::HEADER_X_FORWARDED_ALL

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -19,7 +19,7 @@ $trustedProxies = $_SERVER[ 'TRUSTED_PROXIES' ] ?? false;
 if ( $trustedProxies ) {
 	Request::setTrustedProxies(
 		explode( ',', $trustedProxies ),
-		Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST
+		Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO
 	);
 }
 


### PR DESCRIPTION
Remove a deprecated and removed constant.

Bug: T384115