### PR TITLE
Do not try to remove non-existent files

### DIFF
--- a/src/Util/Util.php
+++ b/src/Util/Util.php
@@ -124,8 +124,12 @@ class Util {
 			: 'ltr';
 	}
 
-	public static function removeFile( $fileName ) {
-		$process = new Process( [ 'rm', realpath( $fileName ) ] );
+	public static function removeFile( $fileName ): void {
+		$realFilename = realpath( $fileName );
+		if ( !$realFilename ) {
+			return;
+		}
+		$process = new Process( [ 'rm', $realFilename ] );
 		$process->mustRun();
 	}
 


### PR DESCRIPTION
Sometimes generated files (PDFs etc) are removed by another process before the code in ConvertGenerator::create() is run. This adds a check, to avoid trying to remove non-existent files.

Bug: T387239